### PR TITLE
Change to unit test so that it doesn't require the setup of multiple loopback devices.

### DIFF
--- a/src/main/java/com/google/code/gossip/GossipService.java
+++ b/src/main/java/com/google/code/gossip/GossipService.java
@@ -47,6 +47,9 @@ public class GossipService {
   }
 
   public void start() {
+    String address = get_gossipManager().getMyself().getHost() + ":" + get_gossipManager().getMyself().getPort();
+    LOGGER.debug( "Starting: " + _gossipManager.getName() + " - " + address );
+
     _gossipManager.start();
   }
 

--- a/src/test/java/io/teknek/gossip/TenNodeThreeSeedTest.java
+++ b/src/test/java/io/teknek/gossip/TenNodeThreeSeedTest.java
@@ -9,6 +9,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 
+import org.apache.log4j.Logger;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -20,6 +21,7 @@ import com.google.code.gossip.event.GossipListener;
 import com.google.code.gossip.event.GossipState;
 
 public class TenNodeThreeSeedTest {
+  private static final Logger log = Logger.getLogger( TenNodeThreeSeedTest.class );
 
   @Test
   public void test() throws UnknownHostException, InterruptedException{
@@ -33,15 +35,19 @@ public class TenNodeThreeSeedTest {
 
   public void abc() throws InterruptedException, UnknownHostException{
     GossipSettings settings = new GossipSettings();
+
+    log.info( "Adding seed nodes" );
     int seedNodes = 3;
     List<GossipMember> startupMembers = new ArrayList<>();
     for (int i = 1; i < seedNodes+1; ++i) {
-      startupMembers.add(new RemoteGossipMember("127.0.0." + i, 2000, i + ""));
+      startupMembers.add(new RemoteGossipMember("127.0.0.1", 50000 + i, i + ""));
     }
+
+    log.info( "Adding clients" );
     final List<GossipService> clients = new ArrayList<>();
     final int clusterMembers = 5;
     for (int i = 1; i < clusterMembers+1; ++i) {
-      GossipService gossipService = new GossipService("127.0.0." + i, 2000, i + "", 
+      GossipService gossipService = new GossipService("127.0.0.1", 50000 + i, i + "",
               startupMembers, settings,
               new GossipListener(){
         @Override


### PR DESCRIPTION
Instead of using addresses in the format of `"127.0.0." + i` it now instead uses a first address of 127.0.0.1 with variable ports in the form of `50000 + i`. This way straight out of the repo you can run the tests, and to some degree achieves the same level of functional testing.

Also added a small additional bit of debug logging in `GossipService` as well as some `INFO` logging in the test - as I figure it's a test that should be suitable.

(Also chose port 50,000 as the base, as that's the generally advised area for non-standard ports.)