### PR TITLE
Added test for `StartupSettings` and documentation of use - in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,46 @@ Later we can check that the nodes discover each other
   }
 ```
 
+Usage with Settings File
+-----
+
+For a very simple client setup with a settings file you first need a JSON file such as:
+
+```json
+[{
+  "id":"419af818-0114-4c7b-8fdb-952915335ce4",
+  "port":50001,
+  "gossip_interval":1000,
+  "cleanup_interval":10000,
+  "members":[
+    {"host":"127.0.0.1", "port":50000}
+  ]
+}]
+```
+
+where:
+
+* `id` - is a unique id for this node (you can use any string, but above we use a UUID)
+* `port` - the port to use on the default adapter on the node's machine
+* `gossip_interval` - how often (in milliseconds) to gossip list of members to other node(s)
+* `cleanup_interval` - when to remove 'dead' nodes (in milliseconds)
+* `members` - initial seed nodes
+
+Then starting a local node is as simple as:
+
+```java
+GossipService gossipService = new GossipService(
+  StartupSettings.fromJSONFile( "node_settings.json" )
+);
+gossipService.start();
+```
+
+And then when all is done, shutdown with:
+
+```java
+gossipService.shutdown();
+```
+
 Event Listener
 ------
 
@@ -49,6 +89,9 @@ The status can be polled using the getters that return immutable lists.
    List<LocalGossipMember> getMemberList()
    public List<LocalGossipMember> getDeadList()
 ```
+
+These can be accessed from the `GossipManager` on your `GossipService`, e.g:
+`gossipService.get_gossipManager().getMemberList();`
 
 Users can also attach an event listener:
 

--- a/src/main/java/com/google/code/gossip/GossipService.java
+++ b/src/main/java/com/google/code/gossip/GossipService.java
@@ -29,7 +29,7 @@ public class GossipService {
    */
   public GossipService(StartupSettings startupSettings) throws InterruptedException,
           UnknownHostException {
-    this(InetAddress.getLocalHost().getHostAddress(), startupSettings.getPort(), "",
+    this(InetAddress.getLocalHost().getHostAddress(), startupSettings.getPort(), startupSettings.getId(),
              startupSettings.getGossipMembers(), startupSettings
                     .getGossipSettings(), null);
   }

--- a/src/test/java/io/teknek/gossip/StartupSettingsTest.java
+++ b/src/test/java/io/teknek/gossip/StartupSettingsTest.java
@@ -1,0 +1,79 @@
+package io.teknek.gossip;
+
+import com.google.code.gossip.GossipMember;
+import com.google.code.gossip.GossipService;
+import com.google.code.gossip.GossipSettings;
+import com.google.code.gossip.StartupSettings;
+import org.apache.log4j.Logger;
+import org.json.JSONException;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests support of using {@code StartupSettings} and thereby reading
+ * setup config from file.
+ */
+public class StartupSettingsTest {
+  private static final Logger log = Logger.getLogger( StartupSettingsTest.class );
+
+  @Test
+  public void testUsingSettingsFile() throws IOException, InterruptedException, JSONException {
+    File settingsFile = File.createTempFile("gossipTest",".json");
+    log.debug( "Using settings file: " + settingsFile.getAbsolutePath() );
+    settingsFile.deleteOnExit();
+    writeSettingsFile(settingsFile);
+
+    // Start the other simple node that the settings file points to
+    GossipService firstService = new GossipService(
+      "127.0.0.1", 50000, UUID.randomUUID().toString(),
+      new ArrayList<GossipMember>(), new GossipSettings(), null
+    );
+    firstService.start();
+
+    // Start a node with the settings file
+    GossipService serviceUnderTest = new GossipService(
+      StartupSettings.fromJSONFile( settingsFile )
+    );
+    serviceUnderTest.start();
+
+    // Let the sync up
+    TimeUnit.SECONDS.sleep(2);
+
+    // Check the results
+    assertEquals(1, firstService.get_gossipManager().getMemberList().size() );
+    assertEquals(1, serviceUnderTest.get_gossipManager().getMemberList().size() );
+    assertTrue(
+      firstService.get_gossipManager().getMemberList().size() ==
+      serviceUnderTest.get_gossipManager().getMemberList().size() );
+
+    firstService.shutdown();
+    serviceUnderTest.shutdown();
+  }
+
+  private void writeSettingsFile( File target ) throws IOException {
+    String settings =
+            "[{\n" + // It is odd that this is meant to be in an array, but oh well.
+            "  \"id\":\"" + UUID.randomUUID() + "\",\n" +
+            "  \"port\":50001,\n" +
+            "  \"gossip_interval\":1000,\n" +
+            "  \"cleanup_interval\":10000,\n" +
+            "  \"members\":[\n" +
+            "    {\"host\":\"127.0.0.1\", \"port\":50000}\n" +
+            "  ]\n" +
+            "}]";
+
+    log.info( "Using settings file with contents of:\n---\n" + settings + "\n---" );
+    FileOutputStream output = new FileOutputStream(target);
+    output.write( settings.getBytes() );
+    output.close();
+  }
+}

--- a/src/test/java/io/teknek/gossip/TenNodeThreeSeedTest.java
+++ b/src/test/java/io/teknek/gossip/TenNodeThreeSeedTest.java
@@ -52,11 +52,12 @@ public class TenNodeThreeSeedTest {
               new GossipListener(){
         @Override
         public void gossipEvent(GossipMember member, GossipState state) {
-          System.out.println(member+" "+ state);
+          log.info(member+" "+ state);
         }
       });
       clients.add(gossipService);
       gossipService.start();
+      gossipService.get_gossipManager().getMemberList();
     }
     TUnit.assertThat(new Callable<Integer> (){
       public Integer call() throws Exception {


### PR DESCRIPTION
* Also tweaked the `StartupSettings` so that it now reads in an `id` for the node, rather than just resulting in a blank `id`
* Moved some logging from stdout to log4j
* Full `maven test` passing

Arguably this would result in a version change, as the settings file format has changed and now requires an id field. However we could make it optional, but it seems odd to have nodes with no ids - so if people update to the new version then they should do this.